### PR TITLE
Dockerfiles for OpenMS 2.3

### DIFF
--- a/openms/releases/2.3/lib/Dockerfile
+++ b/openms/releases/2.3/lib/Dockerfile
@@ -1,0 +1,16 @@
+FROM hroest/openms_dependencies 
+
+WORKDIR /
+RUN git clone https://github.com/OpenMS/OpenMS.git && cd /OpenMS && git checkout tags/Release2.3.0 && rm -rf .git
+
+RUN mkdir openms-build
+WORKDIR /openms-build
+
+## only b/c screwed up cmake ...
+RUN sudo apt-get remove -y cmake cmake-data && sudo -E apt-get update && sudo apt-get -y install cmake
+
+RUN /usr/bin/cmake -DCMAKE_PREFIX_PATH="/usr/;/usr/local" -DOPENMS_CONTRIB_LIBS="/contrib-build/"  -DBOOST_USE_STATIC=OFF -DHAS_XSERVER=Off ../OpenMS
+
+# make OpenMS library
+RUN make OpenMS -j6
+

--- a/openms/releases/2.3/py/Dockerfile
+++ b/openms/releases/2.3/py/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get install -y python-pip python-dev python-numpy
 RUN pip install nose
 RUN pip install -U setuptools
 RUN pip install Cython==0.25.2
-RUN pip install autowrap==0.11.0
+RUN pip install autowrap==0.13.1
 RUN cmake -DCMAKE_PREFIX_PATH="/usr/;/usr/local" -DOPENMS_CONTRIB_LIBS="/contrib-build/" -DBOOST_USE_STATIC=OFF -DHAS_XSERVER=Off -DPYOPENMS=On ../OpenMS
 
 # make OpenMS library

--- a/openms/releases/2.3/py/Dockerfile
+++ b/openms/releases/2.3/py/Dockerfile
@@ -1,0 +1,20 @@
+FROM hroest/openms-lib-2.3
+
+WORKDIR /openms-build
+
+RUN apt-get install -y python-pip python-dev python-numpy
+RUN pip install nose
+RUN pip install -U setuptools
+RUN pip install Cython==0.25.2
+RUN pip install autowrap==0.11.0
+RUN cmake -DCMAKE_PREFIX_PATH="/usr/;/usr/local" -DOPENMS_CONTRIB_LIBS="/contrib-build/" -DBOOST_USE_STATIC=OFF -DHAS_XSERVER=Off -DPYOPENMS=On ../OpenMS
+
+# make OpenMS library
+RUN make pyopenms
+
+# install
+WORKDIR /openms-build/pyOpenMS
+RUN python setup.py install
+WORKDIR /
+ENV PATH="/openms-build/bin/:${PATH}"
+

--- a/openms/releases/2.3/tools/Dockerfile
+++ b/openms/releases/2.3/tools/Dockerfile
@@ -1,0 +1,10 @@
+FROM hroest/openms-lib-2.3
+
+WORKDIR /openms-build
+
+# make OpenMS all
+RUN make TOPP -j6 && make UTILS -j6
+
+WORKDIR /
+ENV PATH="/openms-build/bin/:${PATH}"
+


### PR DESCRIPTION
Dockerfiles for OpenMS 2.3

Change names to "2.3"
Introduced -DOPENMS_CONTRIB_LIBS="/contrib-build/"
Change version to autowrap==0.13.1

Tested on Docker Mac (18.03.0-ce-mac59), High Sierra (10.13.3)  
